### PR TITLE
Php54

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "barttyrant/php_genderize",
     "description": "Genderize.io handler for PHP",
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.4"
     },
     "authors": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -14,7 +14,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.0"
+        "php": ">=5.4"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
Since php's short array syntax is used (`[]`) we must require php 5.4.
